### PR TITLE
use return for proper restart

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -168,6 +168,7 @@ class Game(arcade.Window):
             if key == 32:
                 self.setup()
                 self.state = GameStates.RUNNING
+                return
             elif key == ord("q"):
                 raise SystemExit
 


### PR DESCRIPTION
I just placed a return statement to stop any further code execution when the space bar is pressed for a restart

Fix for the error **Ceres445** issued:

` if self.focus_word.word == "":
AttributeError: 'NoneType' object has no attribute 'word'`